### PR TITLE
fixed modal style to match UI

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -54,8 +54,17 @@ font-family: var(--text)
 
  #myBtn{
     background-color: #363636;
-    color: #fff
-   }
+    color: #fff;
+    border-style: none;
+    font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 16px;
+    padding: 8px 12px;
+    }
+
+    #myBtn:hover{
+        background-color: #292929;
+       }
+       
   .modal {
     display: none; /* Hidden by default */
     position: fixed; /* Stay in place */
@@ -71,7 +80,10 @@ font-family: var(--text)
   /* Modal Content/Box */
   .modal-content {
     color:black;
-    background-color: #fefefe;
+    background-color: #e8e8e8;
+    font-family: BlinkMacSystemFont,-apple-system,"Segoe UI",Roboto,Oxygen,Ubuntu,Cantarell,"Fira Sans","Droid Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    text-align: center;
+    font-size: large;
     margin: 15% auto; /* 15% from the top and centered */
     padding: 20px;
     border: 1px solid #888;


### PR DESCRIPTION
Changed the following:

- Modal button background color now #363636 to match nav design
- Modal button font, font size and padding now match other nav buttons
- changed modal button border-style to "none" to match nav buttons
- added hover pseudo-class to modal button with background color #292929 to match nav button hover state/color
- changed background color of modal message box (modal-content) to #e8e8e8
- changed modal-content font size to 'large'