### PR TITLE
fixed title h1 to match the rest of the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
     
     <section class="section">
       <div class="container">
-        <h1 class="title">Top 10 Texas State Campgrounds</h1>
+        <h1 class="title">Texas Camping Planner</h1>
         <p class="subtitle">Find a campground and check weather conditions</p>
      <div class="About" id="about">
      <h1>About</h1>


### PR DESCRIPTION
fixed title above the campgrounds section to say "Texas Camping Planner" instead of "top 10 texas campgrounds"